### PR TITLE
Fix slurm bugs resulting in erroneous "Validity check for at end of stage * detected missing files"

### DIFF
--- a/bin/ashs_lib.sh
+++ b/bin/ashs_lib.sh
@@ -373,36 +373,35 @@ function qwait()
     done
     while true; do
         all_completed=true
-        echo $JOB_ARRAY
         for JOBID in "${JOB_ARRAY[@]}"; do
-            echo "Checking status of job $JOBID"
             STATE=$(sacct -j "$JOBID" --format=State --noheader | awk '{print $1}' | head -n 1)
 
             if [[ -z "$STATE" ]]; then
-                echo "Warning: Job $JOBID not found in sacct yet."
+                echo -e "\tWarning: Job $JOBID not found in sacct yet."
                 all_completed=false
             elif [[ "$STATE" != "COMPLETED" ]]; then
                 if [[ "$STATE" == "PENDING" || "$STATE" == "RUNNING" ]]; then
-                    echo "Job $JOBID is still $STATE."
+                    echo -e "\tJob $JOBID is still $STATE."
                     all_completed=false
                 else
-                    echo "Error: Job $JOBID finished with state '$STATE', not COMPLETED."
+                    echo -e "\tError: Job $JOBID finished with state '$STATE', not COMPLETED."
                     exit 1
                 fi
             else
-                echo "Job $JOBID completed successfully."
+                echo -e "\tJob $JOBID completed successfully."
             fi
+            sleep 5
         done
 
         if $all_completed; then
-            echo "All jobs completed successfully. Continuing..."
+            echo -e "\tAll jobs completed successfully. Continuing..."
             break
         fi
         
-        waittime=60
-        echo "Waiting $waittime seconds before checking again..."
-        sleep $waittime
-done
+        wait_time=180
+        echo "Waiting $wait_time seconds before checking again..."
+        sleep $wait_time
+  done
   elif [[ $ASHS_USE_LSF ]]; then
     bsub -K -o /dev/null -w "ended($1)" /bin/sleep 1
   fi

--- a/bin/ashs_lib.sh
+++ b/bin/ashs_lib.sh
@@ -166,7 +166,9 @@ function qsubmit_sync()
     bsub -K -o /dev/null -w "ended(${MYNAME})" /bin/sleep 1
     /bin/sleep 0.5
   elif [[ $ASHS_USE_SLURM ]]; then
-    sbatch $QOPTS -o $ASHS_WORK/dump/${UNIQ_NAME}_%j.out -W -D . $*
+    JOB_ID=$(sbatch $QOPTS -o $ASHS_WORK/dump/${UNIQ_NAME}_%j.out -W -D . $* \
+		| awk '{print $4}')
+    qwait $JOB_ID
   else
     fake_qsub $MYNAME $*
   fi
@@ -199,7 +201,7 @@ function qsubmit_single_array()
   elif [[ $ASHS_USE_SLURM ]]; then
 
     # Launch separate jobs
-    local DEPSTRING="afterany"
+    local DEPSTRING=""
     for p1 in $PARAM; do
 
       JOB_ID=$(sbatch $QOPTS -o $ASHS_WORK/dump/${UNIQ_NAME}_%j.out -D . $* $p1 \
@@ -216,7 +218,7 @@ function qsubmit_single_array()
   elif [[ $ASHS_USE_SLURM ]]; then
 
     # Launch separate jobs
-    local DEPSTRING="afterany"
+    local DEPSTRING=""
     for p1 in $PARAM; do
       
       JOB_ID=$(sbatch $QOPTS -o $ASHS_WORK/dump/${UNIQ_NAME}_%j.out -D . $* $p1 \
@@ -257,6 +259,7 @@ function qsubmit_single_array()
     qwait "${UNIQ_NAME}_*"
 
   fi
+  echo $DEPSTRING
 }
 
 
@@ -289,7 +292,7 @@ function qsubmit_double_array()
   elif [[ $ASHS_USE_SLURM ]]; then
 
     # Launch separate jobs
-    local DEPSTRING="afterany"
+    local DEPSTRING=""
     for p1 in $PARAM1; do
       for p2 in $PARAM2; do
 
@@ -307,7 +310,7 @@ function qsubmit_double_array()
   elif [[ $ASHS_USE_SLURM ]]; then
 
     # Launch separate jobs
-    local DEPSTRING="afterany"
+    local DEPSTRING=""
     for p1 in $PARAM1; do
       for p2 in $PARAM2; do
       
@@ -351,6 +354,7 @@ function qsubmit_double_array()
     qwait "${UNIQ_NAME}_*"
 
   fi
+  echo $DEPSTRING
 }
 
 
@@ -360,7 +364,45 @@ function qwait()
   if [[ $ASHS_USE_QSUB ]]; then
     qsub -b y -sync y -j y -o /dev/null -cwd -hold_jid "$1" /bin/sleep 1
   elif [[ $ASHS_USE_SLURM ]]; then
-    srun -d $1 $QOPTS /bin/sleep 1
+    # check if all jobs have completed
+    JOBS=$1
+    IFS=':' read -ra RAW_ARRAY <<< "$JOBS"
+    JOB_ARRAY=()
+    for JOBID in "${RAW_ARRAY[@]}"; do
+        [[ -n "$JOBID" ]] && JOB_ARRAY+=("$JOBID")
+    done
+    while true; do
+        all_completed=true
+        echo $JOB_ARRAY
+        for JOBID in "${JOB_ARRAY[@]}"; do
+            echo "Checking status of job $JOBID"
+            STATE=$(sacct -j "$JOBID" --format=State --noheader | awk '{print $1}' | head -n 1)
+
+            if [[ -z "$STATE" ]]; then
+                echo "Warning: Job $JOBID not found in sacct yet."
+                all_completed=false
+            elif [[ "$STATE" != "COMPLETED" ]]; then
+                if [[ "$STATE" == "PENDING" || "$STATE" == "RUNNING" ]]; then
+                    echo "Job $JOBID is still $STATE."
+                    all_completed=false
+                else
+                    echo "Error: Job $JOBID finished with state '$STATE', not COMPLETED."
+                    exit 1
+                fi
+            else
+                echo "Job $JOBID completed successfully."
+            fi
+        done
+
+        if $all_completed; then
+            echo "All jobs completed successfully. Continuing..."
+            break
+        fi
+        
+        waittime=60
+        echo "Waiting $waittime seconds before checking again..."
+        sleep $waittime
+done
   elif [[ $ASHS_USE_LSF ]]; then
     bsub -K -o /dev/null -w "ended($1)" /bin/sleep 1
   fi

--- a/bin/ashs_lib.sh
+++ b/bin/ashs_lib.sh
@@ -354,7 +354,6 @@ function qsubmit_double_array()
     qwait "${UNIQ_NAME}_*"
 
   fi
-  echo $DEPSTRING
 }
 
 


### PR DESCRIPTION
These changes fix bugs in usage of the slurm scheduler. Currently, `qwait` does not work as documented/expected for slurm because `srun -d $DEPSTRING` does not submit a new job when called in an sbatch allocation and thus will not wait for the dependencies specified by `$DEPSTRING` to be satisfied. As such, functions calling `qwait` do not work as expected. This is a major issue when running `ashs_main.sh`, as it will perform validity checks (`ashs_check_main`) prematurely, often crashing and outputting the following error: 

> Validity check at end of stage * detected missing files

To fix this, `qwait` is modified herein to poll `sacct` every minute to check whether each child job has completed before progressing to the next step. In addition, `qwait` is added to `qsubmit_sync` to ensure that the submitted job completes before continuing.  
This fix should address [this issue](https://github.com/pyushkevich/ashs/issues/9).